### PR TITLE
Make our Rake requirement more liberal

### DIFF
--- a/em-jack.gemspec
+++ b/em-jack.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'eventmachine', ['>= 0.12.10']
 
   s.add_development_dependency 'bundler', ['~> 1.0.13']
-  s.add_development_dependency 'rake',    ['~> 0.8.7']
+  s.add_development_dependency 'rake',    ['>= 0.8.7']
   s.add_development_dependency 'rspec',   ['~> 2.6']
 
   s.files        = `git ls-files`.split("\n")


### PR DESCRIPTION
This is to correct an overly aggressive requirement for Rake to be within the 0.8 version series that I introduced today. We're not hurt by allowing 0.9, and in fake it'll probably make life less noisy for some.
