### PR TITLE
Not possible to reserve on connected reliably

### DIFF
--- a/lib/em-jack/connection.rb
+++ b/lib/em-jack/connection.rb
@@ -246,10 +246,12 @@ module EMJack
       @reconnect_proc = nil
       @retries = 0
       succeed
+      @connected = true
       @connected_callback.call if @connected_callback
     end
 
     def disconnected
+      @connected = false
       d = @deferrables.dup
 
       ## if reconnecting, need to fail ourself to remove any callbacks
@@ -319,6 +321,10 @@ module EMJack
 
     def on_connect(&blk)
       @connected_callback = blk
+    end
+
+    def connected?
+      @connected
     end
 
     def received(data)

--- a/lib/em-jack/connection.rb
+++ b/lib/em-jack/connection.rb
@@ -246,6 +246,7 @@ module EMJack
       @reconnect_proc = nil
       @retries = 0
       succeed
+      @connected_callback.call if @connected_callback
     end
 
     def disconnected
@@ -314,6 +315,10 @@ module EMJack
 
     def on_disconnect(&blk)
       @disconnected_callback = blk
+    end
+
+    def on_connect(&blk)
+      @connected_callback = blk
     end
 
     def received(data)


### PR DESCRIPTION
I wanted to reserve after the beanstalkd connection has connected successfully - however this was surprisingly hard to achieve (unless I've just missed something)

Explicitly, this is what I wanted
- Start queue consumer
- Wait for at least 1 connection attempt to fail
- Start beanstalkd
- Queue consumer should connect and reserve on the queue

The `EMJack::Connection` object is a deferrable, however you can't do

```
# Doesn't work
conn = EMJack::Connection.new

conn.callback {
  # reserve on tube
}
```

This doesn't work because `EMJack::Connection` (which is a deferrable) fails on the first unsuccessful connection attempt. The `Connection#disconnected` method calls `set_deferred_status(nil)` which will clear all callbacks.

My conclusion is that the `EMJack::Connection` deferrable is used heavily for internal callbacks and thus it's behaviour can't be changed. Therefore an `on_connect` callback is required.

It's also necessary to have a `connected?` boolean: in the case that code needs to reserve dynamically, it needs to know whether to just reserve of reserve in an `on_connect` callback.

Code is attached but not tested - if you're happy with this addition then I'll add the tests for it :)
