### PR TITLE
Beanstalk connection strings (beanstalk://localhost:11300/default)

### DIFF
--- a/lib/em-jack/connection.rb
+++ b/lib/em-jack/connection.rb
@@ -1,5 +1,6 @@
 require 'eventmachine'
 require 'yaml'
+require 'uri'
 
 module EMJack
   class Connection
@@ -21,9 +22,17 @@ module EMJack
     end
 
     def initialize(opts = {})
-      @host = opts[:host] || 'localhost'
-      @port = opts[:port] || 11300
-      @tube = opts[:tube]
+      case opts
+      when Hash
+        @host = opts[:host] || 'localhost'
+        @port = opts[:port] || 11300
+        @tube = opts[:tube]
+      when String
+        uri = URI.parse(opts)
+        @host = uri.host || 'localhost'
+        @port = uri.port || 11300
+        @tube = uri.path.gsub(/^\//, '') # Kill the leading /
+      end
 
       reset_tube_state
 

--- a/spec/em-jack/connection_spec.rb
+++ b/spec/em-jack/connection_spec.rb
@@ -16,6 +16,26 @@ describe EMJack::Connection do
     EM.stub!(:connect).and_return(connection_mock)
   end
 
+  describe "uri connection string" do
+    let(:conn) do
+      EMJack::Connection.new('beanstalk://leet:1337/leetube')
+    end
+
+    it "should parse host" do
+      conn.host.should eql('leet')
+    end
+
+    it "should parse tube" do
+      connection_mock.should_receive(:send).once.with(:use, "leetube")
+      connection_mock.should_receive(:send).once.with(:watch, "leetube")
+      conn.connected
+    end
+
+    it "should parse port" do
+      conn.port.should eql(1337)
+    end
+  end
+
   describe 'defaults' do
     it 'host of "localhost"' do
       conn.host.should == 'localhost'


### PR DESCRIPTION
In the spirit of Foreman (https://github.com/ddollar/foreman) and moving more configuration into ENV variables; I added support for URL connection strings to EMJack. This lets folks configure EM::Jack in multiple environments easier with something like:

```
EMJack::Connection.new(ENV['BEANSTALK_URL'])
```

and running that application with:

```
bundle exec bin/awesome_app BEANSTALK_URL=beanstalk://production.server:1337/production_tube
```
