### PR TITLE
Handle various connection failures

### DIFF
--- a/lib/em-jack/connection.rb
+++ b/lib/em-jack/connection.rb
@@ -53,7 +53,9 @@ module EMJack
     end
 
     def initialize_tube_state
-      @fiberized ? ause(@use_on_connect) : use(@use_on_connect) if @use_on_connect
+      if @use_on_connect
+        @fiberized ? ause(@use_on_connect) : use(@use_on_connect)
+      end
 
       [@watch_on_connect].flatten.compact.each do |tube|
         @fiberized ? awatch(tube) : watch(tube)

--- a/spec/em-jack/fiber_spec.rb
+++ b/spec/em-jack/fiber_spec.rb
@@ -9,7 +9,7 @@ if RUBY_VERSION > '1.9'
         EM.add_timer(10) { EM.stop }
 
         Fiber.new do
-          bean = EMJack::Connection.new
+          bean = EMJack::Connection.new(:tube => 'emjacktesttube')
           bean.fiber!
 
           bean.put("hello!")
@@ -21,36 +21,77 @@ if RUBY_VERSION > '1.9'
         end.resume
       end
     end
+
     it "should process each job" do
       EM.run do
         EM.add_timer(10) { EM.stop }
-        
+
         job_body = ''
-        
+
         f = Fiber.new do
-          bean = EMJack::Connection.new
+          bean = EMJack::Connection.new(:tube => 'emjacktesttube')
           bean.fiber!
-        
+
           bean.put("hello!")
-          bean.put("bonjour!")   
-          
+          bean.put("bonjour!")
+
           mock = double()
           mock.should_receive(:foo).with("hello!")
           mock.should_receive(:foo).with("bonjour!")
-          
+
           bean.each_job(0) do |job|
             mock.foo(job.body)
             job_body = job.body
             job.delete
           end
-          
+
         end
-        
+
         f.resume
-        
+
         EM.add_timer(1) { EM.stop unless f.alive?; job_body.should eq "bonjour!" unless f.alive? }
-        
+
       end
+    end
+
+    it "should resume the fiber when disconnected" do
+      success = false
+      EM.run do
+        EM.add_timer(10) { EM.stop }
+
+        f = Fiber.new {
+          bean = EMJack::Connection.new(:tube => 'emjacktesttube')
+          bean.fiber!
+
+          EM.add_timer(1) { bean.disconnected }
+          bean.reserve
+
+          success = true
+          EM.stop
+        }.resume
+      end
+
+      success.should be_true
+    end
+
+    it "should not invoke the each_job block when disconnected" do
+      success = true
+      EM.run do
+        EM.add_timer(10) { EM.stop }
+
+        f = Fiber.new {
+          bean = EMJack::Connection.new(:tube => 'emjacktesttube')
+          bean.fiber!
+
+          EM.should_receive(:next_tick) { EM.stop }
+          EM.add_timer(1) { bean.disconnected }
+          bean.each_job do |job|
+            success = false
+          end
+        }.resume
+      end
+
+      success.should be_true
     end
   end
 end


### PR DESCRIPTION
The initial problem I set out to fix was that when the beanstalk server was restarted while each_job was being used, the reserve command would end up on the callback queue prior to the use and watch commands issued by the reconnect method.  When the reconnect restored the connection to the server, the reserve command would then be the first one sent causing us to wait for jobs on the wrong tube.  The proposed fix for this issue is to call the use and watch commands prior to the add_timer call so that they are guaranteed to be on the callback queue prior to the reserve command.

While fixing that issue I noticed that it would work fine if the reconnect succeeded on the first attempt, but the tube state would not be restored if it took 2 or more attempts to reconnect.  This is the same issue discussed in #10 except on a reconnect instead of the initial connection.  The proposed fix for both of these issues is to store the tube to use and the list of tubes to watch in the @use_on_connect and @watch_on_connect instance variables and leave them intact until the connection actually succeeds.

I also found that connection loss in the fiberized version would not result in the fiber being resumed since the deferrable did not have an errback registered.  The proposed fix for this is always register an errback on the deferrable that simply resumes the fiber when called.  Additionally, when this situation arises in each_job, the supplied block will not be invoked since there is no job to pass back to the caller.  Instead, we simply use next_tick just like before to go back to blocking on the reserve call.

Finally, I also added an automatic ignore of the default tube if a specific tube is requested when creating the connection.  The default tube will also automatically be ignored again if it is not in the @watched_tubes list when a reconnect occurs.

I added several tests to cover some of these scenarios and tweaked a couple of existing ones (mostly to handle the ignore behavior).

I probably should have done these as separate commits and pull requests, but got carried away getting it all to work.  If you want some of this reverted or want it split into multiple commits, let me know and I will get is split up.
