### PR TITLE
Split response fix

### DIFF
--- a/em-jack.gemspec
+++ b/em-jack.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'eventmachine', ['>= 0.12.10']
 
-  s.add_development_dependency 'bundler', ['~> 1.0.13']
+  s.add_development_dependency 'bundler', ['~> 1.3.5']
   s.add_development_dependency 'rake',    ['>= 0.8.7']
   s.add_development_dependency 'rspec',   ['~> 2.6']
 

--- a/spec/em-jack/connection_spec.rb
+++ b/spec/em-jack/connection_spec.rb
@@ -425,6 +425,15 @@ describe EMJack::Connection do
       conn.disconnected
       count.should == 1
     end
+
+    it "does not reconnect when the connection was closed intentionally" do
+      conn.stub(:reconnect) { fail }
+      connection_mock.should_receive :close_connection_after_writing
+
+      conn.disconnect
+      conn.disconnected
+      conn.connected?.should == false
+    end
   end
 
   describe 'beanstalk responses' do

--- a/spec/em-jack/connection_spec.rb
+++ b/spec/em-jack/connection_spec.rb
@@ -577,6 +577,18 @@ HERE
       conn.received("RESERVED 9 #{(msg1 + msg2).length}\r\n#{msg1}#{msg2}")
       conn.received("\r\n")
     end
+
+    it 'multiple responses with the \r\n in a separate packet' do
+      df.should_receive(:succeed).with do |stats|
+        stats['id'].should == 2
+      end
+
+      df2 = conn.add_deferrable
+      df2.should_receive(:fail).with(:deadline_soon)
+
+      conn.received("OK 142\r\n---\nid: 2\ntube: default\nstate: reserved\npri: 65536\nage: 2\ndelay: 0\nttr: 3\ntime-left: 0\nreserves: 1\ntimeouts: 0\nreleases: 0\nburies: 0\nkicks: 0\n")
+      conn.received("\r\nDEADLINE_SOON\r\n")
+    end
   end
 
   context 'passed blocks' do

--- a/spec/em-jack/connection_spec.rb
+++ b/spec/em-jack/connection_spec.rb
@@ -8,12 +8,12 @@ describe EMJack::Connection do
   end
 
   let(:connection_mock) do
-    connection_mock = mock(:conn)
+    connection_mock = double(:conn)
     connection_mock
   end
 
   before(:each) do
-    EM.stub!(:connect).and_return(connection_mock)
+    EM.stub(:connect).and_return(connection_mock)
   end
 
   describe "uri connection string" do
@@ -404,11 +404,11 @@ describe EMJack::Connection do
 
       5.times { conn.disconnected }
       conn.connected
-      lambda { conn.disconnected }.should_not raise_error(EMJack::Disconnected)
+      lambda { conn.disconnected }.should_not raise_error
     end
 
     it 'handles deferrables added during the fail phase' do
-      EM.stub!(:add_timer)
+      EM.stub(:add_timer)
 
       count = 0
       blk = Proc.new do

--- a/spec/em-jack/job_spec.rb
+++ b/spec/em-jack/job_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe EMJack::Job do
-  let (:conn ) { mock(:conn) }
+  let (:conn) { double(:conn) }
 
   it 'converts jobid to an integer' do
     j = EMJack::Job.new(nil, "1", "body")


### PR DESCRIPTION
Did not handle case where packet boundaries split a body from its line terminator exactly. Line terminator not consumed, nor anything past it. For example:

```
OK 5\r\n12345
\r\nDELETED 10\r\n
```

Considerably simplified multi-packet reading and body-extraction logic.
